### PR TITLE
Fix keystore exception.

### DIFF
--- a/src/main/java/duo/labs/webauthn/util/CredentialSafe.java
+++ b/src/main/java/duo/labs/webauthn/util/CredentialSafe.java
@@ -174,8 +174,7 @@ public class CredentialSafe {
     public KeyPair getKeyPairByAlias(@NonNull String alias) throws VirgilException {
         KeyStore.Entry keyEntry;
         try {
-            keyEntry = keyStore.getEntry(alias, null);
-            PrivateKey privateKey = ((KeyStore.PrivateKeyEntry) keyEntry).getPrivateKey();
+            PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, null);
             PublicKey publicKey = keyStore.getCertificate(alias).getPublicKey();
             return new KeyPair(publicKey, privateKey);
         } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableEntryException e) {


### PR DESCRIPTION
Hi,

I got the following exception using your lib. (I've a Pixel 3XL running under Android 9 Pie):
```
W/KeyStore: KeyStore exception
    android.os.ServiceSpecificException:  (code 7)
        at android.os.Parcel.createException(Parcel.java:1964)
        at android.os.Parcel.readException(Parcel.java:1918)
        at android.os.Parcel.readException(Parcel.java:1868)
        at android.security.IKeystoreService$Stub$Proxy.get(IKeystoreService.java:786)
        at android.security.KeyStore.get(KeyStore.java:195)
        at android.security.keystore.AndroidKeyStoreSpi.engineGetCertificateChain(AndroidKeyStoreSpi.java:118)
        at java.security.KeyStoreSpi.engineGetEntry(KeyStoreSpi.java:484)
        at java.security.KeyStore.getEntry(KeyStore.java:1560)
        at duo.labs.webauthn.util.CredentialSafe.getKeyPairByAlias(CredentialSafe.java:177)
        at duo.labs.webauthn.Authenticator.makeCredential(Authenticator.java:171)
        at test.thavel.webauthn.MainActivity$register$1.run(MainActivity.kt:44)
        at java.lang.Thread.run(Thread.java:764)
```

Apparently, the proper way to get a private key from the Android keystore (since Android 9) is:
```
PrivateKey privateKey = (PrivateKey) keyStore.getKey("my-alias", null);
```

This PR actually fixes the exception.